### PR TITLE
Großhändler-Positionierung live stellen

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-tor-kaiser.de

--- a/README.md
+++ b/README.md
@@ -61,5 +61,7 @@ Siehe `../todo.txt` für die vollständige Liste (Bildmaterial, GA4-ID, Trustpil
 
 ## Lizenz
 
-Inhalte © Bauprojekt Kaiser GmbH (CC BY-NC-ND 4.0). Quellcode-Layout (Astro-Templates,
-Komponenten) für interne Verwendung.
+Alle Rechte vorbehalten. Copyright © 2026 Bauprojekt Kaiser GmbH, Gladbeck.
+Eine Vervielfältigung, Bearbeitung oder Verbreitung über das gesetzlich Erlaubte
+hinaus ist ohne schriftliche Zustimmung nicht gestattet. Vollständige Bedingungen
+und Ausnahmen (Dritt-Software, Hörmann-Markenmaterial): siehe [`LICENSE.md`](./LICENSE.md).

--- a/src/components/CtaBlock.astro
+++ b/src/components/CtaBlock.astro
@@ -10,7 +10,7 @@ interface Props {
 
 const {
   title = 'Jetzt unverbindlich beraten lassen',
-  subtitle = `Rufen Sie uns an oder schreiben Sie uns — wir melden uns innerhalb eines Werktags zurück. Persönliche Beratung in unserem Verkaufsbüro in ${company.address.city} jederzeit möglich.`,
+  subtitle = `Rufen Sie uns an oder schreiben Sie uns — wir melden uns innerhalb eines Werktags zurück. Eine persönliche Beratung vereinbaren wir gerne direkt bei Ihnen vor Ort.`,
   emailSubject = 'Anfrage Tor-Kaiser',
   variant = 'default',
 } = Astro.props;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,8 +16,8 @@ import {
       </a>
       <h3>{company.legalName}</h3>
       <p class="footer-tagline">
-        Hörmann Fachhändler für Gladbeck und das Ruhrgebiet — seit
-        {company.yearsLabelLong} Jahren in {company.generation}. Generation.
+        Hörmann Fachhändler für Gladbeck und das Ruhrgebiet — Familienbetrieb seit
+        {company.familyBusinessSince} in {company.generation}. Generation.
       </p>
 
       {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -74,7 +74,7 @@ import {
         <li>📠 Fax: {company.contact.fax}</li>
       </ul>
       <p class="footer-hours">
-        <strong>Öffnungszeiten:</strong><br />
+        <strong>Telefonisch erreichbar:</strong><br />
         {company.openingHours.text}
       </p>
     </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -54,7 +54,7 @@ const nav = [
   <div class="topbar">
     <div class="container-wrap topbar-inner">
       <span class="topbar-info">
-        <strong>{company.partnerStatus}</strong> · seit {company.yearsLabel} Jahren in Gladbeck
+        <strong>{company.partnerStatus}</strong> · Familienbetrieb seit {company.familyBusinessSince}
       </span>
       <span class="topbar-contact">
         <a href={phoneHref}>📞 {company.contact.phone}</a>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -42,7 +42,7 @@ const webpSrc = hasWebpVariant ? webpFromJpg(image) : null;
         <a href={secondaryCta.href} class="btn btn-outline">{secondaryCta.label}</a>
       </div>
       <ul class="hero-bullets">
-        <li>✓ Über 50 Jahre Erfahrung — 4. Generation</li>
+        <li>✓ Über 75 Jahre Erfahrung — Familienbetrieb in 4. Generation</li>
         <li>✓ Original Hörmann-Produkte und -Ersatzteile</li>
         <li>✓ Fachgerechte Montage durch eigenes Team</li>
         <li>✓ 24/7 Notdienst für Gladbeck und Umgebung</li>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -44,7 +44,7 @@ const webpSrc = hasWebpVariant ? webpFromJpg(image) : null;
       <ul class="hero-bullets">
         <li>✓ Über 75 Jahre Erfahrung — Familienbetrieb in 4. Generation</li>
         <li>✓ Original Hörmann-Produkte und -Ersatzteile</li>
-        <li>✓ Fachgerechte Montage durch eigenes Team</li>
+        <li>✓ Montage durch feste Hörmann-Partnerbetriebe</li>
         <li>✓ 24/7 Notdienst für Gladbeck und Umgebung</li>
       </ul>
     </div>

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -1,0 +1,111 @@
+---
+// Visuelle Firmengeschichte — vier Generationen Familie Kaiser.
+// Datenquelle: `history` aus src/data/company.ts (Single Source of Truth).
+import { history } from '../data/company';
+---
+
+<ol class="timeline">
+  {
+    history.map((entry) => (
+      <li class="timeline-item">
+        <span class="timeline-marker" aria-hidden="true" />
+        <div class="timeline-body">
+          <span class="timeline-year">{entry.year}</span>
+          <h3 class="timeline-title">{entry.title}</h3>
+          <span class="timeline-person">{entry.person}</span>
+          <p class="timeline-text">{entry.text}</p>
+        </div>
+      </li>
+    ))
+  }
+</ol>
+
+<style>
+  .timeline {
+    list-style: none;
+    margin: 1.75rem 0 0;
+    padding: 0;
+  }
+
+  .timeline-item {
+    position: relative;
+    margin: 0;
+    padding-left: 2.75rem;
+    padding-bottom: 2rem;
+  }
+
+  .timeline-item:last-child {
+    padding-bottom: 0;
+  }
+
+  /* durchgehende vertikale Linie — jedes Element zeichnet sein Segment */
+  .timeline-item::before {
+    content: '';
+    position: absolute;
+    left: 9px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--color-border);
+  }
+
+  .timeline-item:first-child::before {
+    top: 1rem;
+  }
+
+  .timeline-item:last-child::before {
+    bottom: auto;
+    height: 1rem;
+  }
+
+  /* Punkt auf der Linie */
+  .timeline-marker {
+    position: absolute;
+    left: 0;
+    top: 0.45rem;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--color-surface);
+    border: 3px solid var(--color-brand);
+    box-sizing: border-box;
+  }
+
+  /* aktuelle Generation hervorheben */
+  .timeline-item:last-child .timeline-marker {
+    background: var(--color-brand);
+    box-shadow: 0 0 0 4px rgba(0, 58, 125, 0.12);
+  }
+
+  .timeline-year {
+    display: inline-block;
+    background: var(--color-brand);
+    color: #fff;
+    font-weight: 700;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+    padding: 0.2rem 0.7rem;
+    border-radius: 999px;
+  }
+
+  .timeline-title {
+    margin: 0.55rem 0 0.1rem;
+    font-size: 1.15rem;
+    color: var(--color-brand);
+  }
+
+  .timeline-person {
+    display: block;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-ink-muted);
+    margin-bottom: 0.45rem;
+  }
+
+  .timeline-text {
+    margin: 0;
+    color: var(--color-ink-soft);
+    line-height: 1.6;
+  }
+</style>

--- a/src/components/TrustBar.astro
+++ b/src/components/TrustBar.astro
@@ -21,8 +21,8 @@ import { company } from '../data/company';
       <span>Notdienst</span>
     </div>
     <div class="trust-item">
-      <strong>Eigenes</strong>
-      <span>Montage-Team</span>
+      <strong>Feste</strong>
+      <span>Montagepartner</span>
     </div>
     <div class="trust-item">
       <strong>Original</strong>

--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -32,7 +32,7 @@ export const cities: City[] = [
     localContext:
       'Gladbeck zählt rund 75.500 Einwohner und liegt zentral im Nordwesten des Ruhrgebiets. Die historischen Stadtteile Brauck, Butendorf, Rentfort und Zweckel sind geprägt von Reihenhäusern, freistehenden Einfamilienhäusern und kleineren Mehrfamilienhäusern — alle typisch mit Einzel- oder Doppelgaragen, die mit Sectional- oder Schwingtoren von Hörmann ausgestattet werden. Im Gewerbegebiet Brauck und im Industriegebiet Wittringen finden sich Logistik-, Handwerks- und Produktionsbetriebe, die auf Industrie-Sectionaltore, Schnelllauftore und Rolltore angewiesen sind.',
     serviceNote:
-      'Da unser Sitz und Lager in der Bülser Straße in Gladbeck liegen, garantieren wir besonders kurze Reaktionszeiten — im Regelfall noch am selben Tag.',
+      'Mit unserem Firmensitz in Gladbeck garantieren wir besonders kurze Reaktionszeiten — im Regelfall noch am selben Tag.',
     heroImage: '/img/produkte/standorte/gladbeck.jpg',
     heroImageAlt: 'Hörmann Schwingtor Berry Motiv 985 in Anthrazitgrau RAL 7016 — montiert in Gladbeck',
   },
@@ -68,7 +68,7 @@ export const cities: City[] = [
     localContext:
       'Gelsenkirchen mit rund 260.000 Einwohnern ist die größte Nachbarstadt im Osten und ein traditioneller Industriestandort. Im südlichen Stadtgebiet (Ückendorf, Rotthausen, Schalke) bestehen viele Altbauten und Stadthäuser mit kleinformatigen Garagen — hier sind Hörmann Renomatic Sectionaltore und Schwingtore die beliebteste Wahl. Im Norden Buer, Resse und Hassel überwiegen Einfamilienhäuser. Die großen Industrieareale rund um den Schalker Verein, den Stadthafen und das Gewerbegebiet Bismarck setzen seit Jahrzehnten auf Hörmann Industrietore, Rolltore und Schnelllauftore aus unserer Hand.',
     serviceNote:
-      'In Gelsenkirchen erreichen wir Sie binnen 20 Minuten — Notdienst und Service-Termine bieten wir hier mit eigener Mannschaft an.',
+      'In Gelsenkirchen erreichen wir Sie binnen 20 Minuten — Notdienst und Service-Termine sind hier über unsere festen Partnerbetriebe besonders schnell verfügbar.',
     heroImage: '/img/produkte/standorte/gelsenkirchen.jpg',
     heroImageAlt: 'Hörmann Schwingtor Berry Motiv 984 in Verkehrsweiß RAL 9016 — Referenz Gelsenkirchen',
   },

--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -28,7 +28,7 @@ export const cities: City[] = [
     districts: ['Mitte', 'Brauck', 'Butendorf', 'Ellinghorst', 'Rentfort', 'Zweckel', 'Schultendorf'],
     industrialAreas: ['Gewerbegebiet Brauck', 'Wittringer Industriegebiet', 'Zweckel-Süd'],
     description:
-      'Unser Heimatstandort im nördlichen Ruhrgebiet — seit über 50 Jahren in Gladbeck verwurzelt.',
+      'Unser Heimatstandort im nördlichen Ruhrgebiet — als Familienbetrieb seit 1950 in Gladbeck verwurzelt.',
     localContext:
       'Gladbeck zählt rund 75.500 Einwohner und liegt zentral im Nordwesten des Ruhrgebiets. Die historischen Stadtteile Brauck, Butendorf, Rentfort und Zweckel sind geprägt von Reihenhäusern, freistehenden Einfamilienhäusern und kleineren Mehrfamilienhäusern — alle typisch mit Einzel- oder Doppelgaragen, die mit Sectional- oder Schwingtoren von Hörmann ausgestattet werden. Im Gewerbegebiet Brauck und im Industriegebiet Wittringen finden sich Logistik-, Handwerks- und Produktionsbetriebe, die auf Industrie-Sectionaltore, Schnelllauftore und Rolltore angewiesen sind.',
     serviceNote:

--- a/src/data/company.ts
+++ b/src/data/company.ts
@@ -5,13 +5,24 @@ export const company = {
   legalName: 'Bauprojekt Kaiser GmbH',
   tradeName: 'Tor-Kaiser',
   managingDirector: 'Paul Kaiser',
-  founded: 1975,
+
+  // --- Firmengeschichte · vier Generationen Familienbetrieb ---
+  // 1950  Kaiser Bau — der Urgroßvater gründet den Familienbetrieb im Bauhandwerk
+  // 1972  Kaiser Baubedarfartikel GmbH — der Großvater, Beginn der Hörmann-Spezialisierung
+  // 2000  Bauprojekt Kaiser GmbH — der Vater, gegründet am 01.04.2000 (heutige Firma)
+  // heute Paul Kaiser führt das Unternehmen in 4. Generation fort
+  familyBusinessSince: 1950,
+  hoermannSince: 1972,
+  founded: 2000,
+  foundingDate: '2000-04-01',
   generation: 4,
-  // Marketing-Anker: bewusst statisch, NICHT dynamisch aus `founded` berechnen.
-  // "50+ Jahre" ist eine Brand-Story (50 = halbes Jahrhundert), kein Counter.
-  // Erst in ~2030/2035 manuell auf "55+" / "60" wechseln.
-  yearsLabel: '50+',
-  yearsLabelLong: 'über 50',
+
+  // Marketing-Anker: bewusst statisch, NICHT dynamisch berechnen.
+  // Bezieht sich auf die Familientradition seit 1950 (über 75 Jahre / drei Viertel
+  // Jahrhundert). Die Hörmann-Tätigkeit (seit den 1970ern) steht im Text als Phrase.
+  // Erst in ~2030 manuell prüfen.
+  yearsLabel: '75+',
+
   partnerStatus: 'Hörmann Fachhändler',
 
   address: {
@@ -111,3 +122,41 @@ export const socialLinks: SocialLink[] = (Object.entries(company.social) as [Soc
   }));
 
 export const socialSameAs: string[] = socialLinks.map((s) => s.url);
+
+// --- Firmengeschichte ------------------------------------------------------
+// Datenquelle für die Zeitleiste auf der Über-uns-Seite (Timeline.astro).
+// Vier Generationen Familie Kaiser — eine durchgehende Linie von 1950 bis heute.
+
+export interface HistoryEntry {
+  year: string;
+  title: string;
+  person: string;
+  text: string;
+}
+
+export const history: HistoryEntry[] = [
+  {
+    year: '1950',
+    title: 'Kaiser Bau',
+    person: 'Urgroßvater',
+    text: 'Der Urgroßvater legt mit der Kaiser Bau den Grundstein — der Beginn von vier Generationen Bauhandwerk im Ruhrgebiet.',
+  },
+  {
+    year: '1972',
+    title: 'Kaiser Baubedarfartikel GmbH',
+    person: 'Großvater',
+    text: 'Der Großvater eröffnet am Bahnhof Gladbeck-West einen Baumarkt, wie es ihn damals noch selten gab — lange vor den großen Ketten von heute und in der Stadt bestens bekannt. Hier beginnt die Spezialisierung der Familie auf Hörmann.',
+  },
+  {
+    year: '2000',
+    title: 'Bauprojekt Kaiser GmbH',
+    person: 'Vater',
+    text: 'Am 1. April gründet der Vater die heutige Bauprojekt Kaiser GmbH und vereint Beratung, Verkauf, Montage und Service unter einem Dach in Gladbeck.',
+  },
+  {
+    year: 'Heute',
+    title: 'Vierte Generation',
+    person: 'Paul Kaiser',
+    text: 'Paul Kaiser führt das Unternehmen in vierter Generation fort — mit eingespieltem Team, eigenem Montageservice und unverändertem Anspruch an Hörmann-Qualität und persönliche Verlässlichkeit.',
+  },
+];

--- a/src/data/company.ts
+++ b/src/data/company.ts
@@ -139,7 +139,7 @@ export const history: HistoryEntry[] = [
     year: '1950',
     title: 'Kaiser Bau',
     person: 'Urgroßvater',
-    text: 'Der Urgroßvater legt mit der Kaiser Bau den Grundstein — der Beginn von vier Generationen Bauhandwerk im Ruhrgebiet.',
+    text: 'Der Urgroßvater legt mit der Kaiser Bau den Grundstein — der Beginn einer Familientradition, die bis heute über vier Generationen reicht.',
   },
   {
     year: '1972',
@@ -151,12 +151,12 @@ export const history: HistoryEntry[] = [
     year: '2000',
     title: 'Bauprojekt Kaiser GmbH',
     person: 'Vater',
-    text: 'Am 1. April gründet der Vater die heutige Bauprojekt Kaiser GmbH und vereint Beratung, Verkauf, Montage und Service unter einem Dach in Gladbeck.',
+    text: 'Am 1. April gründet der Vater die heutige Bauprojekt Kaiser GmbH und vereint Beratung, Verkauf und Service an einem Standort in Gladbeck.',
   },
   {
     year: 'Heute',
     title: 'Vierte Generation',
     person: 'Paul Kaiser',
-    text: 'Paul Kaiser führt das Unternehmen in vierter Generation fort — mit eingespieltem Team, eigenem Montageservice und unverändertem Anspruch an Hörmann-Qualität und persönliche Verlässlichkeit.',
+    text: 'Paul Kaiser führt das Unternehmen in vierter Generation fort — mit eingespieltem Team, einem festen Netz an Partnerbetrieben und unverändertem Anspruch an Hörmann-Qualität und persönliche Verlässlichkeit.',
   },
 ];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,7 +64,7 @@ const localBusinessSchema = {
       closes: '14:00',
     },
   ],
-  foundingDate: String(company.founded),
+  foundingDate: company.foundingDate,
   founder: {
     '@type': 'Person',
     name: 'Familie Kaiser',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,7 +17,7 @@ const faqs = [
   {
     question: 'Sind Sie offizieller Hörmann-Partner?',
     answer:
-      'Ja. Die Bauprojekt Kaiser GmbH ist seit über 50 Jahren autorisierter Hörmann-Fachhändler für Gladbeck und das nördliche Ruhrgebiet. Wir vertreiben ausschließlich Original-Hörmann-Produkte und nutzen ausschließlich Original-Ersatzteile.',
+      'Ja. Als Familienbetrieb sind wir bereits seit den 1970er-Jahren autorisierter Hörmann-Fachhändler für Gladbeck und das nördliche Ruhrgebiet — heute in vierter Generation durch die Bauprojekt Kaiser GmbH fortgeführt. Wir vertreiben ausschließlich Original-Hörmann-Produkte und nutzen ausschließlich Original-Ersatzteile.',
   },
   {
     question: 'In welcher Region sind Sie tätig?',
@@ -58,7 +58,7 @@ const homeSchema = {
 
 <BaseLayout title={title} description={description} schema={homeSchema}>
   <Hero
-    eyebrow={`Seit ${company.yearsLabel} Jahren · ${company.generation}. Generation in Gladbeck`}
+    eyebrow={`Familienbetrieb seit ${company.familyBusinessSince} · ${company.generation}. Generation in Gladbeck`}
     title="Hörmann Tore, Türen & Antriebe — vom Fachbetrieb aus Gladbeck."
     subtitle="Beratung, Verkauf, Montage, Wartung und Notdienst. Wir liefern und montieren Garagentore, Industrietore, Haustüren und Antriebe von Hörmann in Gladbeck, Bottrop, Gelsenkirchen, Essen, Recklinghausen und im gesamten nördlichen Ruhrgebiet."
     image="/img/produkte/start/hero.jpg"
@@ -78,10 +78,11 @@ const homeSchema = {
         <span class="eyebrow">Warum Tor-Kaiser?</span>
         <h2>Familienbetrieb in vierter Generation — mit Hörmann-DNA</h2>
         <p class="lead">
-          Seit den 70er-Jahren tragen wir den Namen Hörmann in das nördliche Ruhrgebiet. Was klein
-          begann, ist heute ein eingespieltes Team aus Beratern und Monteuren mit über
-          50&nbsp;Jahren Praxiserfahrung — und genau das Mindset, das man von einem
-          Familienunternehmen erwartet: persönlich, zuverlässig, langfristig.
+          Seit den 1970er-Jahren tragen wir den Namen Hörmann ins nördliche Ruhrgebiet — die
+          Wurzeln unseres Familienbetriebs reichen bis 1950 zurück. Was damals klein begann, ist
+          heute ein eingespieltes Team aus Beratern und Monteuren mit der Praxiserfahrung aus
+          vier Generationen — und genau das Mindset, das man von einem Familienunternehmen
+          erwartet: persönlich, zuverlässig, langfristig.
         </p>
       </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,7 +59,7 @@ const homeSchema = {
 <BaseLayout title={title} description={description} schema={homeSchema}>
   <Hero
     eyebrow={`Familienbetrieb seit ${company.familyBusinessSince} · ${company.generation}. Generation in Gladbeck`}
-    title="Hörmann Tore, Türen & Antriebe — vom Fachbetrieb aus Gladbeck."
+    title="Hörmann Tore, Türen & Antriebe — vom Hörmann-Fachhändler aus Gladbeck."
     subtitle="Beratung, Verkauf, Montage, Wartung und Notdienst. Wir liefern und montieren Garagentore, Industrietore, Haustüren und Antriebe von Hörmann in Gladbeck, Bottrop, Gelsenkirchen, Essen, Recklinghausen und im gesamten nördlichen Ruhrgebiet."
     image="/img/produkte/start/hero.jpg"
     imageAlt="Hörmann Garagen-Sectionaltor D-Sicke Silkgrain in Anthrazitgrau RAL 7016 mit ThermoSafe Haustür"
@@ -80,8 +80,9 @@ const homeSchema = {
         <p class="lead">
           Seit den 1970er-Jahren tragen wir den Namen Hörmann ins nördliche Ruhrgebiet — die
           Wurzeln unseres Familienbetriebs reichen bis 1950 zurück. Was damals klein begann, ist
-          heute ein eingespieltes Team aus Beratern und Monteuren mit der Praxiserfahrung aus
-          vier Generationen — und genau das Mindset, das man von einem Familienunternehmen
+          heute ein eingespieltes Team aus erfahrenen Beraterinnen und Beratern — mit einem
+          festen Netz Hörmann-geschulter Montagepartner an unserer Seite und der Praxiserfahrung
+          aus vier Generationen. Genau das Mindset, das man von einem Familienunternehmen
           erwartet: persönlich, zuverlässig, langfristig.
         </p>
       </div>
@@ -90,16 +91,17 @@ const homeSchema = {
         <div class="card">
           <h3>🛠 Beratung & Aufmaß</h3>
           <p>
-            Persönliche Beratung in unserem Verkaufsbüro in Gladbeck oder direkt bei Ihnen vor
-            Ort. Wir messen exakt aus und entwickeln eine Lösung, die optisch und technisch zu
-            Ihrem Haus oder Betrieb passt.
+            Persönliche Beratung am Telefon, per E-Mail oder direkt bei Ihnen vor Ort — wir
+            bringen Tormuster und RAL-Farbfächer mit. Wir messen exakt aus und entwickeln eine
+            Lösung, die optisch und technisch zu Ihrem Haus oder Betrieb passt.
           </p>
         </div>
         <div class="card">
-          <h3>📐 Montage durch eigenes Team</h3>
+          <h3>📐 Montage durch feste Partnerbetriebe</h3>
           <p>
-            Wir arbeiten mit festangestellten Hörmann-geschulten Monteuren — keine Subunternehmer.
-            Das spürt man im Ergebnis: passgenau, sauber, mit Gewährleistung.
+            Die Montage übernehmen Hörmann-geschulte Fachbetriebe, mit denen wir seit
+            Jahrzehnten zusammenarbeiten. Das spürt man im Ergebnis: passgenau, sauber,
+            mit Gewährleistung.
           </p>
         </div>
         <div class="card">
@@ -134,7 +136,7 @@ const homeSchema = {
 
   <CtaBlock
     title="Lassen Sie uns über Ihr Tor sprechen."
-    subtitle={`Wir freuen uns auf Ihren Anruf oder Ihre Mail. Unser Verkaufsbüro in der Bülser Straße ist Mo–Fr von 9:00 bis 14:00 für Sie geöffnet — Beratung darüber hinaus selbstverständlich nach Vereinbarung.`}
+    subtitle={`Wir freuen uns auf Ihren Anruf oder Ihre Mail. Telefonisch erreichen Sie uns Mo–Fr von 9:00 bis 14:00 Uhr; eine persönliche Beratung vereinbaren wir gerne direkt bei Ihnen vor Ort.`}
   />
 </BaseLayout>
 

--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -4,7 +4,7 @@ import Breadcrumbs from '../components/Breadcrumbs.astro';
 import { company, phoneHref, emailHref } from '../data/company';
 
 const title = `Kontakt — Tor-Kaiser Gladbeck | Bauprojekt Kaiser GmbH`;
-const description = `Verkaufsbüro und Service in der Bülser Straße 19, 45964 Gladbeck. Telefon ${company.contact.phone}, E-Mail ${company.contact.email}. Mo–Fr 9–14 Uhr.`;
+const description = `Bauprojekt Kaiser GmbH in Gladbeck — Telefon ${company.contact.phone}, E-Mail ${company.contact.email}. Mo–Fr 9–14 Uhr. Beratung und Aufmaß direkt bei Ihnen vor Ort.`;
 
 const mapEmbedUrl = `https://www.openstreetmap.org/export/embed.html?bbox=6.97%2C51.56%2C7.00%2C51.58&layer=mapnik&marker=${company.address.latitude}%2C${company.address.longitude}`;
 const mapsLink = `https://www.google.com/maps/place/${encodeURIComponent(
@@ -39,12 +39,13 @@ const mapsLink = `https://www.google.com/maps/place/${encodeURIComponent(
           </div>
 
           <div class="card">
-            <h2>🏢 Verkaufsbüro</h2>
+            <h2>🏢 Verwaltung & Postanschrift</h2>
             <p>
               <strong>{company.legalName}</strong><br />
               {company.address.street}<br />
               {company.address.postalCode} {company.address.city}
             </p>
+            <p class="muted">Verwaltungssitz — kein Ausstellungsraum. Beratungstermine vereinbaren wir gerne bei Ihnen vor Ort.</p>
             <p><a href={mapsLink} target="_blank" rel="noopener">In Google Maps öffnen ↗</a></p>
           </div>
 
@@ -63,14 +64,12 @@ const mapsLink = `https://www.google.com/maps/place/${encodeURIComponent(
         </div>
 
         <div class="kontakt-extra">
-          <h2>So erreichen Sie uns</h2>
+          <h2>Beratung bei Ihnen vor Ort</h2>
           <p>
-            Mit dem PKW: Ausfahrt Gladbeck-Mitte (B&nbsp;224) oder Gladbeck-Süd (A&nbsp;2). Vor
-            unserem Verkaufsbüro stehen Parkplätze zur Verfügung.
-          </p>
-          <p>
-            Mit dem ÖPNV: Mehrere Linien der Vestischen Straßenbahnen halten in fußläufiger
-            Entfernung an der Bülser Straße.
+            Als Hörmann-Fachhändler kommen wir mit unserem Außendienst direkt zu Ihnen — mit
+            Tormustern, RAL-Farbfächer und allen Unterlagen. So sehen Sie Material und Farben
+            in Ruhe an Ihrem Gebäude, und wir nehmen gleich Maß. Vereinbaren Sie dazu einfach
+            telefonisch oder per E-Mail einen Termin.
           </p>
           <p>
             Fax: {company.contact.fax}<br />

--- a/src/pages/produkte/garagentore/index.astro
+++ b/src/pages/produkte/garagentore/index.astro
@@ -98,7 +98,7 @@ const faqs = [
         <li><strong>Telefonische Erstberatung.</strong> Wir klären die Eckdaten: bestehendes Tor, Maße, Wünsche, Budgetrahmen.</li>
         <li><strong>Aufmaß vor Ort.</strong> Kostenlos und unverbindlich in Gladbeck und Umgebung. Wir prüfen Sturzhöhe, Seitenraum, Bodenanschluss.</li>
         <li><strong>Angebot.</strong> Verbindliche Festpreis-Kalkulation inkl. Anlieferung und Montage.</li>
-        <li><strong>Montage.</strong> Durch unser eigenes, festangestelltes Hörmann-Montageteam.</li>
+        <li><strong>Montage.</strong> Durch feste, Hörmann-geschulte Partnerbetriebe.</li>
         <li><strong>Einweisung & Service.</strong> Wir erklären Ihnen die Bedienung und bieten Ihnen einen Wartungsvertrag an.</li>
       </ol>
     </div>

--- a/src/pages/produkte/garagentore/sectionaltore.astro
+++ b/src/pages/produkte/garagentore/sectionaltore.astro
@@ -172,7 +172,7 @@ const faqs = [
         <li>Telefonische Erstberatung in unserer Sprechzeit Mo–Fr 9–14 Uhr.</li>
         <li>Kostenloser Aufmaß-Termin bei Ihnen vor Ort.</li>
         <li>Verbindliches Festpreis-Angebot mit Lieferzeit.</li>
-        <li>Anlieferung und Montage durch unser eigenes Team — meist an einem Werktag.</li>
+        <li>Anlieferung und Montage durch unsere festen Partnerbetriebe — meist an einem Werktag.</li>
         <li>Einweisung und Hörmann-Garantie.</li>
       </ol>
     </div>

--- a/src/pages/ratgeber/index.astro
+++ b/src/pages/ratgeber/index.astro
@@ -48,7 +48,7 @@ const articles = [
       <h1>Wissen aus vier Generationen Praxis</h1>
       <p class="lead">
         Praktische Artikel rund um Garagentore, Haustüren, Antriebe und Wartung — ehrlich und
-        ohne Marketing-Geschwafel, aus der Sicht eines Fachbetriebs in vierter Generation.
+        ohne Marketing-Geschwafel, aus der Sicht eines Hörmann-Fachhändlers in vierter Generation.
       </p>
 
       <div class="article-grid">

--- a/src/pages/ratgeber/index.astro
+++ b/src/pages/ratgeber/index.astro
@@ -45,7 +45,7 @@ const articles = [
   <section class="section">
     <div class="container-wrap">
       <span class="eyebrow">Ratgeber</span>
-      <h1>Wissen aus über 50 Jahren Praxis</h1>
+      <h1>Wissen aus vier Generationen Praxis</h1>
       <p class="lead">
         Praktische Artikel rund um Garagentore, Haustüren, Antriebe und Wartung — ehrlich und
         ohne Marketing-Geschwafel, aus der Sicht eines Fachbetriebs in vierter Generation.

--- a/src/pages/referenzen.astro
+++ b/src/pages/referenzen.astro
@@ -2,7 +2,6 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import CtaBlock from '../components/CtaBlock.astro';
-import { company } from '../data/company';
 
 const title = 'Referenzen — Projekte aus Industrie, Verwaltung und Wohnbau | Tor-Kaiser';
 const description =
@@ -69,7 +68,7 @@ const projects = [
       <span class="eyebrow">Referenzen</span>
       <h1>Projekte, auf die wir stolz sind</h1>
       <p class="lead">
-        {company.yearsLabel} Jahre Hörmann-Erfahrung — von der kleinen Garage bis zum
+        Erfahrung aus vier Generationen Familienbetrieb — von der kleinen Garage bis zum
         Industriekomplex. Eine Auswahl unserer Referenzen:
       </p>
 

--- a/src/pages/service/montage.astro
+++ b/src/pages/service/montage.astro
@@ -8,7 +8,7 @@ import FAQ from '../../components/FAQ.astro';
 
 const title = 'Montage von Hörmann Toren & Türen | Tor-Kaiser Gladbeck';
 const description =
-  'Fachgerechte Montage von Hörmann Garagentoren, Industrietoren, Haustüren und Antrieben — durch das eigene Team von Bauprojekt Kaiser GmbH. Im gesamten Ruhrgebiet.';
+  'Fachgerechte Montage von Hörmann Garagentoren, Industrietoren, Haustüren und Antrieben — durch feste, Hörmann-geschulte Partnerbetriebe der Bauprojekt Kaiser GmbH. Im gesamten Ruhrgebiet.';
 
 const serviceSchema = {
   '@context': 'https://schema.org',
@@ -51,10 +51,10 @@ const faqs = [
 
   <Hero
     eyebrow="Service"
-    title="Montage — durch das eigene Hörmann-Team."
-    subtitle="Vom Aufmaß über die Demontage des Bestands­tores bis zur sauberen Übergabe: Wir montieren mit festangestellten, Hörmann-geschulten Monteuren — keine Subunternehmer."
+    title="Montage — durch feste Hörmann-Partnerbetriebe."
+    subtitle="Vom Aufmaß über die Demontage des Bestands­tores bis zur sauberen Übergabe: Die Montage übernehmen Hörmann-geschulte Fachbetriebe, mit denen wir seit Jahrzehnten zusammenarbeiten."
     image="/img/montage.png"
-    imageAlt="Hörmann Montage durch Tor-Kaiser"
+    imageAlt="Hörmann Tor-Montage durch unsere Partnerbetriebe"
   />
 
   <TrustBar />
@@ -63,7 +63,7 @@ const faqs = [
     <div class="container-wrap prose-content">
       <h2>Was uns ausmacht</h2>
       <ul>
-        <li><strong>Eigenes Team.</strong> Festangestellte Monteure mit langjähriger Hörmann-Erfahrung</li>
+        <li><strong>Feste Partnerbetriebe.</strong> Hörmann-geschulte Fachbetriebe mit langjähriger Erfahrung — eingespielt mit uns</li>
         <li><strong>Werkzeug auf dem neuesten Stand.</strong> Spezialwerkzeug für Federpakete, Aufmaß-Lasertechnik, vollausgestattete Service-Fahrzeuge</li>
         <li><strong>Sauberkeit am Arbeitsplatz.</strong> Schutzfolien, Abdeckungen, Reinigung nach der Montage</li>
         <li><strong>Gewährleistung.</strong> Auf unsere Montage gewähren wir die gesetzliche Gewährleistung — zusätzlich zur Hörmann-Werksgarantie</li>
@@ -94,12 +94,12 @@ const faqs = [
         <li><strong>Kostenloses Aufmaß</strong> bei Ihnen vor Ort (Gladbeck und Umgebung)</li>
         <li><strong>Verbindliches Angebot</strong> mit Festpreis und Lieferzeit</li>
         <li><strong>Anlieferung</strong> des Tor- bzw. Türmaterials in der vereinbarten Woche</li>
-        <li><strong>Montage</strong> durch unser Team — meist an einem Werktag</li>
+        <li><strong>Montage</strong> durch unsere Partnerbetriebe — meist an einem Werktag</li>
         <li><strong>Übergabe & Einweisung</strong> — wir erklären die Bedienung und übergeben alle Unterlagen</li>
         <li><strong>Service-Empfehlung</strong> — wir bieten Ihnen einen Wartungsvertrag an</li>
       </ol>
 
-      <h2>Referenzen unseres Montage-Teams</h2>
+      <h2>Referenzprojekte</h2>
       <ul>
         <li>IKEA Einrichtungshaus Dortmund</li>
         <li>Sparkasse Wuppertal</li>

--- a/src/pages/standorte/[city].astro
+++ b/src/pages/standorte/[city].astro
@@ -157,7 +157,7 @@ const faqs = [
 
         <h2>Service in {city.name}</h2>
         <ul>
-          <li><a href="/service/montage/">Montage</a> durch eigenes Hörmann-geschultes Team</li>
+          <li><a href="/service/montage/">Montage</a> durch feste, Hörmann-geschulte Partnerbetriebe</li>
           <li><a href="/service/wartung/">Wartung &amp; UVV-Prüfung</a> mit Prüfprotokoll</li>
           <li><a href="/service/reparatur/">Reparatur</a> nach Sturmschäden, Auffahrunfällen, Federbruch</li>
           <li><a href="/service/notdienst/">24/7 Notdienst</a> mit kurzen Reaktionszeiten in {city.name}</li>

--- a/src/pages/ueber-uns.astro
+++ b/src/pages/ueber-uns.astro
@@ -16,23 +16,24 @@ const description = `Bauprojekt Kaiser GmbH — Familienbetrieb seit 1950, Hörm
   <section class="section">
     <div class="container-narrow prose-content">
       <span class="eyebrow">Über uns</span>
-      <h1>Vier Generationen Familie Kaiser — Ihr Hörmann-Fachbetrieb in Gladbeck</h1>
+      <h1>Vier Generationen Familie Kaiser — Ihr Hörmann-Fachhändler in Gladbeck</h1>
       <p class="lead">
         Vier Generationen, ein Auftrag: hochwertige Tore und Türen ins Ruhrgebiet bringen.
         Was 1950 mit der Kaiser Bau begann und sich über die Jahrzehnte zum spezialisierten
-        Hörmann-Fachbetrieb entwickelte, führt Paul Kaiser heute mit einem eingespielten Team
-        aus Beraterinnen, Beratern und Monteuren fort.
+        Hörmann-Fachhandel entwickelte, führt Paul Kaiser heute mit einem eingespielten Team
+        und einem festen Netz an Montagepartnern fort.
       </p>
 
       <h2>Vier Generationen — eine Familie</h2>
       <p>
-        Hinter Tor-Kaiser steht keine anonyme Kette, sondern eine Familie, die das Bauhandwerk
-        im Ruhrgebiet seit 1950 weitergibt — von Generation zu Generation, jeweils mit eigener
-        Firma, aber immer mit demselben Anspruch an Qualität und Verlässlichkeit.
+        Hinter Tor-Kaiser steht keine anonyme Kette, sondern eine Familie, die seit 1950
+        hochwertige Tore und Bauelemente ins Ruhrgebiet bringt — von Generation zu Generation,
+        jeweils mit eigener Firma, aber immer mit demselben Anspruch an Qualität und
+        Verlässlichkeit.
       </p>
       <Timeline />
 
-      <h2>Hörmann-Fachbetrieb aus Überzeugung</h2>
+      <h2>Hörmann-Fachhandel aus Überzeugung</h2>
       <p>
         Bereits in den 1970er-Jahren entschied sich die Familie Kaiser, voll auf Hörmann zu
         setzen — eine Entscheidung, die sich bis heute bewährt hat. Hörmann ist mit Stammsitz
@@ -49,8 +50,8 @@ const description = `Bauprojekt Kaiser GmbH — Familienbetrieb seit 1950, Hörm
           erfahrenen Fachkräften — keine Callcenter, keine Standardisierung.
         </li>
         <li>
-          <strong>Vor Ort.</strong> Verkauf, Beratung und Werkstatt sitzen am gleichen Standort
-          in der Bülser Straße 19 in Gladbeck.
+          <strong>Wir kommen zu Ihnen.</strong> Beratung, Aufmaß und Musteransicht direkt bei
+          Ihnen vor Ort — mit Tormustern, RAL-Farbfächer und allen Unterlagen im Gepäck.
         </li>
         <li>
           <strong>Komplettlösung.</strong> Beratung, Aufmaß, Lieferung, Montage, Wartung,
@@ -61,8 +62,8 @@ const description = `Bauprojekt Kaiser GmbH — Familienbetrieb seit 1950, Hörm
           verwenden ausschließlich Original-Hörmann-Ersatzteile — keine Nachbauten.
         </li>
         <li>
-          <strong>Eigenes Montage-Team.</strong> Festangestellt, Hörmann-geschult, mit Erfahrung
-          aus tausenden Montagen.
+          <strong>Feste Montagepartner.</strong> Hörmann-geschulte Fachbetriebe, mit denen wir
+          seit Jahrzehnten zusammenarbeiten — mit Erfahrung aus tausenden Montagen.
         </li>
       </ul>
 

--- a/src/pages/ueber-uns.astro
+++ b/src/pages/ueber-uns.astro
@@ -1,12 +1,13 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
+import Timeline from '../components/Timeline.astro';
 import TrustBar from '../components/TrustBar.astro';
 import CtaBlock from '../components/CtaBlock.astro';
 import { company } from '../data/company';
 
-const title = `Über uns — ${company.yearsLabel} Jahre Hörmann in Gladbeck | Bauprojekt Kaiser GmbH`;
-const description = `Familienbetrieb in 4. Generation: Die Bauprojekt Kaiser GmbH ist seit ${company.yearsLabel} Jahren Hörmann-Fachhändler in Gladbeck. Erfahren Sie mehr über Geschichte, Team und Werte hinter Tor-Kaiser.`;
+const title = `Über uns: Familienbetrieb in 4. Generation seit 1950 — Tor-Kaiser`;
+const description = `Bauprojekt Kaiser GmbH — Familienbetrieb seit 1950, Hörmann-Fachhändler in Gladbeck seit den 1970er-Jahren. Vier Generationen Familie Kaiser: Geschichte, Team und Werte hinter Tor-Kaiser.`;
 ---
 
 <BaseLayout title={title} description={description}>
@@ -15,21 +16,30 @@ const description = `Familienbetrieb in 4. Generation: Die Bauprojekt Kaiser Gmb
   <section class="section">
     <div class="container-narrow prose-content">
       <span class="eyebrow">Über uns</span>
-      <h1>Hörmann in Gladbeck — Familie Kaiser seit {company.yearsLabel} Jahren</h1>
+      <h1>Vier Generationen Familie Kaiser — Ihr Hörmann-Fachbetrieb in Gladbeck</h1>
       <p class="lead">
-        Vier Generationen, ein Auftrag: Hochwertige Hörmann-Tore und -Türen ins Ruhrgebiet
-        bringen. Was in den 1970er-Jahren mit dem Großvater begann, führt Paul Kaiser heute mit
-        einem eingespielten Team aus Beraterinnen, Beratern und Monteuren fort.
+        Vier Generationen, ein Auftrag: hochwertige Tore und Türen ins Ruhrgebiet bringen.
+        Was 1950 mit der Kaiser Bau begann und sich über die Jahrzehnte zum spezialisierten
+        Hörmann-Fachbetrieb entwickelte, führt Paul Kaiser heute mit einem eingespielten Team
+        aus Beraterinnen, Beratern und Monteuren fort.
       </p>
 
-      <h2>Vier Generationen — eine Spezialisierung</h2>
+      <h2>Vier Generationen — eine Familie</h2>
       <p>
-        Bereits in den 1970er-Jahren beschloss die Familie Kaiser, sich auf Hörmann-Produkte zu
-        konzentrieren — eine Entscheidung, die sich bis heute bewährt hat. Hörmann ist mit
-        Stammsitz in Steinhagen und Werken im Ruhrgebiet (u.&nbsp;a. in Werne und Bottrop) der
-        führende europäische Hersteller von Toren, Türen und Antriebstechnik. Diese Nähe zum
-        Hersteller ermöglicht uns kurze Lieferzeiten, schnelle Verfügbarkeit von Ersatzteilen und
-        einen direkten Draht zur Hörmann-Technik.
+        Hinter Tor-Kaiser steht keine anonyme Kette, sondern eine Familie, die das Bauhandwerk
+        im Ruhrgebiet seit 1950 weitergibt — von Generation zu Generation, jeweils mit eigener
+        Firma, aber immer mit demselben Anspruch an Qualität und Verlässlichkeit.
+      </p>
+      <Timeline />
+
+      <h2>Hörmann-Fachbetrieb aus Überzeugung</h2>
+      <p>
+        Bereits in den 1970er-Jahren entschied sich die Familie Kaiser, voll auf Hörmann zu
+        setzen — eine Entscheidung, die sich bis heute bewährt hat. Hörmann ist mit Stammsitz
+        in Steinhagen und Werken im Ruhrgebiet (u.&nbsp;a. in Werne und Bottrop) der führende
+        europäische Hersteller von Toren, Türen und Antriebstechnik. Diese Nähe zum Hersteller
+        ermöglicht uns kurze Lieferzeiten, schnelle Verfügbarkeit von Ersatzteilen und einen
+        direkten Draht zur Hörmann-Technik.
       </p>
 
       <h2>Was uns ausmacht</h2>
@@ -60,10 +70,10 @@ const description = `Familienbetrieb in 4. Generation: Die Bauprojekt Kaiser Gmb
       <table class="data-table">
         <tbody>
           <tr><th>Firmenname</th><td>{company.legalName}</td></tr>
-          <tr><th>Gegründet</th><td>{company.founded}</td></tr>
+          <tr><th>Familientradition</th><td>seit {company.familyBusinessSince} — vier Generationen Familie Kaiser</td></tr>
+          <tr><th>Heutige Firma gegründet</th><td>1. April {company.founded}</td></tr>
           <tr><th>Geschäftsführer</th><td>{company.managingDirector}</td></tr>
-          <tr><th>Generation</th><td>{company.generation}. Generation</td></tr>
-          <tr><th>Hörmann-Partnerstatus</th><td>{company.partnerStatus}</td></tr>
+          <tr><th>Hörmann-Partnerstatus</th><td>{company.partnerStatus} — seit den 1970er-Jahren</td></tr>
           <tr><th>Sitz</th><td>{company.address.street}, {company.address.postalCode} {company.address.city}</td></tr>
           <tr><th>Handelsregister</th><td>{company.registration.hrb}, {company.registration.court}</td></tr>
         </tbody>


### PR DESCRIPTION
## Was geht live

Merge von `dev` nach `publish` — löst das Deployment auf GitHub Pages aus.

### Hauptänderung: Positionierung als Großhändler
Die Webseite war fälschlich auf ein eigenes Montage-Team und ein besuchbares Büro mit Werkstatt aufgebaut. Bauprojekt Kaiser ist Hörmann-Fachhändler (Großhandel), kein Handwerksbetrieb.

- Montage-Aussagen durchgängig auf **„feste Partnerbetriebe"** umgestellt — „eigenes Montage-Team", „festangestellte Monteure", „keine Subunternehmer", „eigene Mannschaft" entfernt
- „Verkaufsbüro" → **„Verwaltung & Postanschrift"**; Bülser Straße 19 als Verwaltungssitz gekennzeichnet, Besuchs-Einladungen (Parkplätze, ÖPNV, „für Sie geöffnet") entfernt
- Beratung als mobilen Außendienst formuliert (Tormuster, RAL-Farbfächer)
- Selbstbezeichnung „Fachbetrieb" → „Fachhändler/Fachhandel"
- falsche Angabe „Lager in der Bülser Straße" korrigiert

### Weitere enthaltene Commits
- Firmengeschichte korrigiert (vier Generationen Familie Kaiser)
- Lizenzangabe in README an LICENSE.md angeglichen
- redundantes `/CNAME` im Repo-Root entfernt

## Verifikation
`npm run build` läuft fehlerfrei durch (39 Seiten).