### PR TITLE
Release: Bildkorrekturen — Hero-Crops & Alt-Texte

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -17,7 +17,7 @@ const {
   title,
   subtitle,
   image = '/img/produkte/start/hero.jpg',
-  imageAlt = 'Hörmann Garagentor Sectionaltor in Anthrazitgrau RAL 7016',
+  imageAlt = 'Hörmann Garagen-Sectionaltor in Anthrazit an einem modernen weißen Einfamilienhaus in Hanglage',
   primaryCta = { label: 'Anfrage senden', href: '/anfrage/' },
   secondaryCta = { label: 'Anrufen', href: phoneHref },
   size = 'default',

--- a/src/components/ProductCard.astro
+++ b/src/components/ProductCard.astro
@@ -12,12 +12,17 @@ function webpFromJpg(src: string): string {
 }
 
 const webpSrc = product.image && /\.jpe?g$/i.test(product.image) ? webpFromJpg(product.image) : null;
+
+const cardImageStyle =
+  product.imageFit || product.imagePosition || product.imageBackground
+    ? `--card-image-fit:${product.imageFit ?? 'cover'};--card-image-position:${product.imagePosition ?? 'center'};${product.imageBackground ? `--card-image-background:${product.imageBackground};` : ''}`
+    : undefined;
 ---
 
 <a href={product.href} class="product-card card card-interactive">
   {
     product.image && (
-      <div class="card-image">
+      <div class="card-image" style={cardImageStyle}>
         <picture>
           {webpSrc && <source srcset={webpSrc} type="image/webp" />}
           <img src={product.image} alt={product.imageAlt ?? product.title} loading="lazy" width="400" height="280" />
@@ -46,7 +51,7 @@ const webpSrc = product.image && /\.jpe?g$/i.test(product.image) ? webpFromJpg(p
   .card-image {
     aspect-ratio: 16 / 10;
     overflow: hidden;
-    background: var(--color-surface-alt);
+    background: var(--card-image-background, var(--color-surface-alt));
   }
 
   .card-image picture {
@@ -58,7 +63,8 @@ const webpSrc = product.image && /\.jpe?g$/i.test(product.image) ? webpFromJpg(p
   .card-image img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: var(--card-image-fit, cover);
+    object-position: var(--card-image-position, center);
     transition: transform 0.4s ease;
     display: block;
   }

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -31,7 +31,7 @@ export const products: Product[] = [
       'Sectionaltore öffnen senkrecht nach oben und liegen platzsparend unter der Decke — ideal, wenn vor der Garage jeder Zentimeter zählt.',
     image: '/img/produkte/sectionaltore/hero.jpg',
     imageAlt:
-      'Hörmann Garagen-Sectionaltor D-Sicke Silkgrain in Anthrazitgrau RAL 7016 mit Holzoptik-Inlay',
+      'Hörmann Garagen-Sectionaltor D-Sicke Silkgrain in Fenstergrau RAL 7040',
     gallery: [
       {
         src: '/img/produkte/sectionaltore/detail-1.jpg',
@@ -43,7 +43,7 @@ export const products: Product[] = [
       },
       {
         src: '/img/produkte/sectionaltore/detail-3.jpg',
-        alt: 'Hörmann Sectionaltor D-Sicke Silkgrain in Fenstergrau RAL 7040',
+        alt: 'Hörmann Sectionaltor D-Sicke Silkgrain in Anthrazitgrau RAL 7016, Motiv 500 mit Holzoptik-Inlay',
       },
     ],
     highlights: [

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -15,6 +15,9 @@ export interface Product {
   description: string;
   image?: string;
   imageAlt?: string;
+  imageFit?: 'cover' | 'contain';
+  imagePosition?: string;
+  imageBackground?: string;
   gallery?: ProductGalleryImage[];
   highlights: string[];
 }
@@ -96,6 +99,7 @@ export const products: Product[] = [
       'Das RollMatic Rolltor wickelt sich kompakt unter die Decke und lässt die volle Garagentiefe und -höhe frei.',
     image: '/img/produkte/rolltore/hero.jpg',
     imageAlt: 'Hörmann RollMatic Garagen-Rolltor — Außenansicht',
+    imagePosition: 'center 70%',
     gallery: [
       {
         src: '/img/produkte/rolltore/detail-1.jpg',
@@ -335,6 +339,8 @@ export const products: Product[] = [
       'Original Hörmann Ersatzteile für alle Tor- und Antriebsbaureihen — Torsionsfedern, Laufrollen, Seilbruchsicherungen, Handsender HSE / HS bis 30 Jahre zurück.',
     image: '/img/produkte/ersatzteile/hero.jpg',
     imageAlt: 'Hörmann BiSecur Handsender HSE 4 BS in Anthrazitgrau',
+    imageFit: 'contain',
+    imageBackground: '#fff',
     gallery: [
       {
         src: '/img/produkte/ersatzteile/detail-1.jpg',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,7 +62,7 @@ const homeSchema = {
     title="Hörmann Tore, Türen & Antriebe — vom Hörmann-Fachhändler aus Gladbeck."
     subtitle="Beratung, Verkauf, Montage, Wartung und Notdienst. Wir liefern und montieren Garagentore, Industrietore, Haustüren und Antriebe von Hörmann in Gladbeck, Bottrop, Gelsenkirchen, Essen, Recklinghausen und im gesamten nördlichen Ruhrgebiet."
     image="/img/produkte/start/hero.jpg"
-    imageAlt="Hörmann Garagen-Sectionaltor D-Sicke Silkgrain in Anthrazitgrau RAL 7016 mit ThermoSafe Haustür"
+    imageAlt="Hörmann Garagen-Sectionaltor in Anthrazit an einem modernen weißen Einfamilienhaus in Hanglage"
   />
 
   <TrustBar />


### PR DESCRIPTION
## Summary

- **Hochformat-Hero-Bilder auf Produktkarten korrekt darstellen** (Startseite): Handsender-Foto auf der Ersatzteile-Karte wird komplett angezeigt (`object-fit: contain` + weißer Card-Hintergrund), beim Rolltore-Bild rückt das Tor durch `object-position: center 70%` in den sichtbaren Bereich. Mechanik: drei optionale Felder am `Product`-Interface (`imageFit`, `imagePosition`, `imageBackground`), als CSS-Custom-Properties durch `ProductCard.astro` durchgereicht — andere Karten bleiben unverändert.
- **Alt-Texte und Galerie-Caption an getauschte Bilder angepasst**: Startseite-Hero, Sectionaltore-Hero/Galerie und der Hero-Default-Alt-Text beschreiben jetzt die tatsächlich ausgespielten Bilder.