### PR TITLE
Deploy: Content- und UX-Fixes (5 Commits)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -81,6 +81,11 @@ const nav = [
           <span class="hamburger-label">Menü</span>
         </summary>
         <div class="mobile-panel">
+          <button type="button" class="mobile-close" aria-label="Menü schließen">
+            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+              <path d="M6 6 L18 18 M6 18 L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none" />
+            </svg>
+          </button>
           <ul class="mobile-list">
             {
               nav.map((item) => (
@@ -151,6 +156,11 @@ const nav = [
     document.querySelectorAll('.nav-dropdown[open]').forEach((d) => {
       if (!d.contains(e.target)) d.open = false;
     });
+  });
+  // Mobile-Drawer per X-Button schließen
+  document.querySelector('.mobile-close')?.addEventListener('click', () => {
+    const m = document.getElementById('mobile-menu');
+    if (m) m.open = false;
   });
 </script>
 
@@ -429,6 +439,30 @@ const nav = [
     display: grid;
     gap: 0.6rem;
     margin-top: 1.25rem;
+  }
+
+  .mobile-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    border-radius: 8px;
+    color: var(--color-ink);
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+
+  .mobile-close:hover,
+  .mobile-close:focus-visible {
+    background: var(--color-surface-alt);
+    color: var(--color-brand);
   }
 
   @media (max-width: 1024px) {

--- a/src/data/cities.ts
+++ b/src/data/cities.ts
@@ -48,7 +48,7 @@ export const cities: City[] = [
     description:
       'Direkt benachbarte Großstadt im Süden — ein wichtiger Markt im Hörmann-Stammgebiet.',
     localContext:
-      'Bottrop ist mit rund 117.500 Einwohnern unsere direkte Nachbarstadt im Süden. Hier bedienen wir sowohl die dichten Wohngebiete in Stadtmitte, Eigen und Welheim als auch die Einfamilienhaussiedlungen in Kirchhellen und Grafenwald. Bottrop ist außerdem Sitz des Hörmann Stammwerks (Steinhagen lieferte das Werk, in Bottrop sind weitere Fertigungsstandorte angesiedelt), sodass eine besonders schnelle Verfügbarkeit von Ersatzteilen und Sonderbauten gegeben ist. Industriebetriebe im Welheimer Mark, im ProspectPark und Kirchhellener Heide setzen auf Industrietore, Schnelllauftore und Rollgitter von Hörmann.',
+      'Bottrop ist mit rund 117.500 Einwohnern unsere direkte Nachbarstadt im Süden. Hier bedienen wir sowohl die dichten Wohngebiete in Stadtmitte, Eigen und Welheim als auch die Einfamilienhaussiedlungen in Kirchhellen und Grafenwald. Industriebetriebe im Welheimer Mark, im ProspectPark und Kirchhellener Heide setzen auf Industrietore, Schnelllauftore und Rollgitter von Hörmann.',
     serviceNote:
       'Bottrop liegt nur 15 Minuten von unserem Hauptsitz in Gladbeck entfernt — Notdienst und Montage sind besonders schnell verfügbar.',
     heroImage: '/img/produkte/standorte/bottrop.jpg',

--- a/src/data/company.ts
+++ b/src/data/company.ts
@@ -7,7 +7,7 @@ export const company = {
   managingDirector: 'Paul Kaiser',
 
   // --- Firmengeschichte · vier Generationen Familienbetrieb ---
-  // 1950  Kaiser Bau — der Urgroßvater gründet den Familienbetrieb im Bauhandwerk
+  // 1950  Bauunternehmen Bernhard Kaiser — der Urgroßvater gründet den Familienbetrieb im Bauhandwerk
   // 1972  Kaiser Baubedarfartikel GmbH — der Großvater, Beginn der Hörmann-Spezialisierung
   // 2000  Bauprojekt Kaiser GmbH — der Vater, gegründet am 01.04.2000 (heutige Firma)
   // heute Paul Kaiser führt das Unternehmen in 4. Generation fort
@@ -137,9 +137,9 @@ export interface HistoryEntry {
 export const history: HistoryEntry[] = [
   {
     year: '1950',
-    title: 'Kaiser Bau',
+    title: 'Bauunternehmen Bernhard Kaiser',
     person: 'Urgroßvater',
-    text: 'Der Urgroßvater legt mit der Kaiser Bau den Grundstein — der Beginn einer Familientradition, die bis heute über vier Generationen reicht.',
+    text: 'Der Urgroßvater legt mit dem Bauunternehmen Bernhard Kaiser den Grundstein — der Beginn einer Familientradition, die bis heute über vier Generationen reicht.',
   },
   {
     year: '1972',

--- a/src/data/company.ts
+++ b/src/data/company.ts
@@ -81,10 +81,9 @@ export const emergencyDaytimeHref = `tel:${company.emergency.daytimePhoneE164}`;
 export const emergencyNightHref = `tel:${company.emergency.nightPhoneE164.replace(/\s/g, '')}`;
 
 export function buildMailto(subject: string, body?: string): string {
-  const params = new URLSearchParams();
-  params.set('subject', subject);
-  if (body) params.set('body', body);
-  return `mailto:${company.contact.email}?${params.toString()}`;
+  const parts = [`subject=${encodeURIComponent(subject)}`];
+  if (body) parts.push(`body=${encodeURIComponent(body)}`);
+  return `mailto:${company.contact.email}?${parts.join('&')}`;
 }
 
 export const fullAddress = `${company.address.street}, ${company.address.postalCode} ${company.address.city}`;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -97,7 +97,7 @@ const homeSchema = {
           </p>
         </div>
         <div class="card">
-          <h3>📐 Montage durch feste Partnerbetriebe</h3>
+          <h3>📐 Profi-Montage</h3>
           <p>
             Die Montage übernehmen Hörmann-geschulte Fachbetriebe, mit denen wir seit
             Jahrzehnten zusammenarbeiten. Das spürt man im Ergebnis: passgenau, sauber,

--- a/src/pages/produkte/garagentore/index.astro
+++ b/src/pages/produkte/garagentore/index.astro
@@ -81,7 +81,7 @@ const faqs = [
       <h2>Warum Hörmann?</h2>
       <p>
         Hörmann ist nicht ohne Grund Marktführer: Die Tore werden in Deutschland gefertigt
-        (u. a. in Werne, Steinhagen, Bottrop), erfüllen die anspruchsvollen Normen
+        (u. a. in Steinhagen und Werne), erfüllen die anspruchsvollen Normen
         EN&nbsp;13241 und ASR&nbsp;A1.7 und bieten Schutz-Features wie den Fingerklemmschutz
         bereits in der Standardausstattung.
       </p>

--- a/src/pages/ueber-uns.astro
+++ b/src/pages/ueber-uns.astro
@@ -37,8 +37,8 @@ const description = `Bauprojekt Kaiser GmbH — Familienbetrieb seit 1950, Hörm
       <p>
         Bereits in den 1970er-Jahren entschied sich die Familie Kaiser, voll auf Hörmann zu
         setzen — eine Entscheidung, die sich bis heute bewährt hat. Hörmann ist mit Stammsitz
-        in Steinhagen und Werken im Ruhrgebiet (u.&nbsp;a. in Werne und Bottrop) der führende
-        europäische Hersteller von Toren, Türen und Antriebstechnik. Diese Nähe zum Hersteller
+        in Steinhagen (Ostwestfalen) und einem Werk in Werne am Rand des Ruhrgebiets der
+        führende europäische Hersteller von Toren, Türen und Antriebstechnik. Diese Nähe zum Hersteller
         ermöglicht uns kurze Lieferzeiten, schnelle Verfügbarkeit von Ersatzteilen und einen
         direkten Draht zur Hörmann-Technik.
       </p>

--- a/src/pages/ueber-uns.astro
+++ b/src/pages/ueber-uns.astro
@@ -19,7 +19,7 @@ const description = `Bauprojekt Kaiser GmbH — Familienbetrieb seit 1950, Hörm
       <h1>Vier Generationen Familie Kaiser — Ihr Hörmann-Fachhändler in Gladbeck</h1>
       <p class="lead">
         Vier Generationen, ein Auftrag: hochwertige Tore und Türen ins Ruhrgebiet bringen.
-        Was 1950 mit der Kaiser Bau begann und sich über die Jahrzehnte zum spezialisierten
+        Was 1950 mit dem Bauunternehmen Bernhard Kaiser begann und sich über die Jahrzehnte zum spezialisierten
         Hörmann-Fachhandel entwickelte, führt Paul Kaiser heute mit einem eingespielten Team
         und einem festen Netz an Montagepartnern fort.
       </p>


### PR DESCRIPTION
## Summary
- **Content-Korrekturen**: Hörmann-Werksstandorte richtiggestellt (Bottrop ist kein Werk), Firmenname des Urgroßvaters auf `ueber-uns` korrigiert.
- **Mobile UX**: sichtbarer Schließen-Button im Header-Drawer, gekürzte USP-Kachel-Headline auf der Startseite.
- **mailto-Encoding**: Leerzeichen in Betreff/Body werden jetzt als `%20` statt `+` kodiert (Kompatibilität mit allen Mail-Clients).

## Commits
- 6d32646 fix(anfrage): Leerzeichen in mailto-Links als %20 statt + kodieren
- 58fe7d1 fix(header): sichtbarer Schließen-Button im Mobile-Drawer
- 9e52dce fix(startseite): USP-Kachel-Headline gekürzt für Mobile
- 9de9455 fix(ueber-uns): korrekten Firmennamen des Urgroßvaters verwenden
- 7ee383a fix(content): Hörmann-Werksstandorte korrigieren (Bottrop ist kein Werk)