### PR TITLE
fix(ui): Briefumschlag-Glyph als Emoji rendern

### DIFF
--- a/src/components/CtaBlock.astro
+++ b/src/components/CtaBlock.astro
@@ -26,7 +26,7 @@ const mailtoHref = buildMailto(emailSubject);
     </div>
     <div class="cta-actions">
       <a href={phoneHref} class="btn btn-accent">📞 {company.contact.phone}</a>
-      <a href={mailtoHref} class="btn btn-ghost">✉ Anfrage per E-Mail</a>
+      <a href={mailtoHref} class="btn btn-ghost">✉️ Anfrage per E-Mail</a>
     </div>
   </div>
 </section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -70,7 +70,7 @@ import {
           {company.address.street}<br />{company.address.postalCode} {company.address.city}
         </li>
         <li>📞 <a href={phoneHref}>{company.contact.phone}</a></li>
-        <li>✉ <a href={emailHref}>{company.contact.email}</a></li>
+        <li>✉️ <a href={emailHref}>{company.contact.email}</a></li>
         <li>📠 Fax: {company.contact.fax}</li>
       </ul>
       <p class="footer-hours">

--- a/src/pages/kontakt.astro
+++ b/src/pages/kontakt.astro
@@ -33,7 +33,7 @@ const mapsLink = `https://www.google.com/maps/place/${encodeURIComponent(
           </div>
 
           <div class="card">
-            <h2>✉ E-Mail</h2>
+            <h2>✉️ E-Mail</h2>
             <p><a href={emailHref}><strong>{company.contact.email}</strong></a></p>
             <p class="muted">Antwort innerhalb eines Werktags</p>
           </div>


### PR DESCRIPTION
## Summary
- Variation-Selector `U+FE0F` an alle `✉`-Glyphen angehängt, damit der Browser sie zuverlässig als farbiges Emoji rendert statt als monochromes Textzeichen.
- Betroffen: `CtaBlock.astro`, `Footer.astro`, `kontakt.astro`.