### PR TITLE
Release: Betriebsferien-Banner + Anfrage-Formularfelder

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import { company, phoneHref } from '../data/company';
+import VacationBanner from './VacationBanner.astro';
 
 const nav = [
   {
@@ -62,6 +63,8 @@ const nav = [
       </span>
     </div>
   </div>
+
+  <VacationBanner />
 
   <nav class="mainbar" aria-label="Hauptnavigation">
     <div class="container-wrap mainbar-inner">

--- a/src/components/VacationBanner.astro
+++ b/src/components/VacationBanner.astro
@@ -1,0 +1,79 @@
+---
+import { company } from '../data/company';
+
+const text = company.vacationBanner.trim();
+---
+
+{
+  text && (
+    <div
+      class="vacation-banner"
+      role="status"
+      aria-live="polite"
+      aria-label="Betriebsferien Hinweis"
+    >
+      <div class="vacation-banner-track">
+        <span class="vacation-banner-item">{text}</span>
+        <span class="vacation-banner-sep" aria-hidden="true">•</span>
+        <span class="vacation-banner-item" aria-hidden="true">{text}</span>
+        <span class="vacation-banner-sep" aria-hidden="true">•</span>
+        <span class="vacation-banner-item" aria-hidden="true">{text}</span>
+        <span class="vacation-banner-sep" aria-hidden="true">•</span>
+      </div>
+    </div>
+  )
+}
+
+<style>
+  .vacation-banner {
+    background: var(--color-accent);
+    color: var(--color-ink);
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding-block: 0.45rem;
+    overflow: hidden;
+    border-block: 1px solid rgba(15, 27, 45, 0.08);
+  }
+
+  .vacation-banner-track {
+    display: flex;
+    width: max-content;
+    align-items: center;
+    animation: vacation-marquee 40s linear infinite;
+  }
+
+  .vacation-banner:hover .vacation-banner-track,
+  .vacation-banner:focus-within .vacation-banner-track {
+    animation-play-state: paused;
+  }
+
+  .vacation-banner-item {
+    padding-inline: 2rem;
+    white-space: nowrap;
+  }
+
+  .vacation-banner-sep {
+    opacity: 0.55;
+  }
+
+  @keyframes vacation-marquee {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(calc(-100% / 3));
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .vacation-banner-track {
+      animation: none;
+      justify-content: center;
+      width: 100%;
+    }
+    .vacation-banner-item ~ .vacation-banner-item,
+    .vacation-banner-sep {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/VacationBanner.astro
+++ b/src/components/VacationBanner.astro
@@ -75,5 +75,10 @@ const text = company.vacationBanner.trim();
     .vacation-banner-sep {
       display: none;
     }
+    .vacation-banner-item {
+      white-space: normal;
+      padding-inline: 1rem;
+      text-align: center;
+    }
   }
 </style>

--- a/src/data/company.ts
+++ b/src/data/company.ts
@@ -25,6 +25,12 @@ export const company = {
 
   partnerStatus: 'Hörmann Fachhändler',
 
+  // --- Betriebsferien-Banner -------------------------------------------------
+  // Leer lassen → kein Banner. Text eintragen → Banner erscheint als gelbe
+  // Zeile zwischen dunklem Topbar und Hauptnavigation, mit durchlaufender
+  // Schrift. Nach den Ferien wieder auf '' setzen.
+  vacationBanner: '',
+
   address: {
     street: 'Bülser Straße 19',
     postalCode: '45964',

--- a/src/data/company.ts
+++ b/src/data/company.ts
@@ -29,7 +29,8 @@ export const company = {
   // Leer lassen → kein Banner. Text eintragen → Banner erscheint als gelbe
   // Zeile zwischen dunklem Topbar und Hauptnavigation, mit durchlaufender
   // Schrift. Nach den Ferien wieder auf '' setzen.
-  vacationBanner: '',
+  vacationBanner:
+    'Betriebsferien vom 1. bis 19. Juni 2026 — ab Montag, 22. Juni sind wir wieder für Sie da. In Notfällen nutzen Sie bitte unseren Notdienst.',
 
   address: {
     street: 'Bülser Straße 19',

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -88,11 +88,29 @@ const localBusinessSchema = {
     'Hörmann, Garagentor, Industrietor, Haustür, Antrieb, Gladbeck, Bottrop, Gelsenkirchen, Essen, Notdienst',
 };
 
+const vacationText = company.vacationBanner.trim();
+const specialAnnouncementSchema = vacationText
+  ? {
+      '@context': 'https://schema.org',
+      '@type': 'SpecialAnnouncement',
+      name: `Betriebsferien ${company.legalName}`,
+      text: vacationText,
+      category: 'https://www.wikidata.org/wiki/Q831871',
+      datePosted: new Date().toISOString(),
+      announcementLocation: { '@id': `${siteUrl}/#organization` },
+      publisher: { '@id': `${siteUrl}/#organization` },
+    }
+  : null;
+
+const baseSchemas = specialAnnouncementSchema
+  ? [localBusinessSchema, specialAnnouncementSchema]
+  : [localBusinessSchema];
+
 const allSchemas = schema
   ? Array.isArray(schema)
-    ? [localBusinessSchema, ...schema]
-    : [localBusinessSchema, schema]
-  : [localBusinessSchema];
+    ? [...baseSchemas, ...schema]
+    : [...baseSchemas, schema]
+  : baseSchemas;
 ---
 
 <!doctype html>

--- a/src/pages/anfrage.astro
+++ b/src/pages/anfrage.astro
@@ -7,7 +7,7 @@ const title = 'Anfrage senden — Beratungstermin & Angebot anfordern | Tor-Kais
 const description = `Schreiben Sie uns Ihre Anfrage rund um Hörmann Garagentore, Industrietore, Haustüren oder Antriebe. Wir melden uns binnen eines Werktags — direkt aus Gladbeck.`;
 
 const bodyTemplate = (productHint: string) =>
-  `Guten Tag,\n\nich interessiere mich für ${productHint}.\n\nProjekt-Eckdaten (bitte ergänzen):\n- Adresse / Ort:\n- Maße (B × H) ungefähr:\n- Vorhandenes Tor / Vorhandene Tür: ja / nein, falls ja Modell:\n- Wunschtermin Aufmaß:\n- Sonstiges:\n\nVielen Dank und beste Grüße`;
+  `Guten Tag,\n\nich interessiere mich für ${productHint}.\n\nProjekt-Eckdaten (bitte ergänzen):\n- Name:\n- Telefon (für Rückruf):\n- Adresse / Ort:\n- Maße (B × H) ungefähr:\n- Vorhandenes Tor / Vorhandene Tür: ja / nein, falls ja Modell:\n- Wunschtermin Aufmaß:\n- Sonstiges:\n\nVielen Dank und beste Grüße`;
 
 const options = [
   {


### PR DESCRIPTION
## Summary

- Neues `vacationBanner`-Feld in `src/data/company.ts` als zentrale Stelle für Betriebsferien-Hinweise. Leerer String → kein Banner; Text → gelbe Leiste mit endlos durchlaufender Schrift zwischen dunklem Topbar und Hauptnavigation.
- Pure-CSS-Marquee mit Pause bei Hover/Focus und statischem, mehrzeilig umbrechendem Fallback unter `prefers-reduced-motion: reduce` (auch auf schmalen Viewports voll lesbar).
- Bedingtes Schema.org `SpecialAnnouncement`-JSON-LD im `BaseLayout`, das per `@id` auf das vorhandene `LocalBusiness`-Schema referenziert (Wikidata Q831871 = Betriebsferien). Sobald das Feld leer ist, verschwindet das Schema vollständig aus dem HTML.
- Aktueller Banner-Inhalt: Betriebsferien 1.–19. Juni 2026, Rückkehr Montag 22. Juni, Verweis auf Notdienst statt expliziter Mobilnummer.
- Zusätzlich: Anfrage-E-Mail-Vorlagen ergänzen jetzt Name- und Telefon-Felder (separate Vorarbeit aus `bf10566`).

## Commits

- 6416cde fix(header): Banner-Text auf Mobile mit reduced-motion umbrechen lassen
- 003c2b0 content(header): Betriebsferien 1.–19. Juni 2026 im Banner ankündigen
- 13d0ba0 feat(header): Betriebsferien-Banner mit durchlaufender Schrift
- bf10566 feat(anfrage): Name- und Telefon-Feld in E-Mail-Vorlagen ergänzen